### PR TITLE
fix: Fix test fail flaky on finalizer branch

### DIFF
--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -529,7 +529,7 @@ func (wfc *WorkflowController) processNextPodCleanupItem(ctx context.Context) bo
 					Value:     "true",
 				},
 			}
-			p, err := wfc.getPodFromApi(ctx, namespace, podName)
+			p, err := wfc.getPodFromAPI(ctx, namespace, podName)
 			if err != nil {
 				return err
 			}
@@ -554,7 +554,7 @@ func (wfc *WorkflowController) processNextPodCleanupItem(ctx context.Context) bo
 			}
 		case deletePod:
 			var patch []common.DeleteFinalizerPatch
-			p, err := wfc.getPodFromApi(ctx, namespace, podName)
+			p, err := wfc.getPodFromAPI(ctx, namespace, podName)
 			if err != nil {
 				return err
 			}
@@ -597,7 +597,7 @@ func (wfc *WorkflowController) processNextPodCleanupItem(ctx context.Context) bo
 	return true
 }
 
-func (wfc *WorkflowController) getPodFromApi(ctx context.Context, namespace string, podName string) (*apiv1.Pod, error) {
+func (wfc *WorkflowController) getPodFromAPI(ctx context.Context, namespace string, podName string) (*apiv1.Pod, error) {
 	pod, err := wfc.kubeclientset.CoreV1().Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
 	if err != nil {
 		return nil, err

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -529,19 +529,20 @@ func (wfc *WorkflowController) processNextPodCleanupItem(ctx context.Context) bo
 					Value:     "true",
 				},
 			}
-			obj, _, _ := wfc.podInformer.GetIndexer().GetByKey(namespace + "/" + podName)
-			if p, ok := obj.(*apiv1.Pod); ok {
-				i := slices.Index(p.Finalizers, common.Finalizer)
-				if i >= 0 {
-					patch = append(patch, common.DeleteFinalizerPatch{
-						Operation: "remove",
-						Path:      fmt.Sprintf("/metadata/finalizers/%d", i),
-					})
-				}
+			p, err := wfc.getPodFromApi(ctx, namespace, podName)
+			if err != nil {
+				return err
+			}
+			i := slices.Index(p.Finalizers, common.Finalizer)
+			if i >= 0 {
+				patch = append(patch, common.DeleteFinalizerPatch{
+					Operation: "remove",
+					Path:      fmt.Sprintf("/metadata/finalizers/%d", i),
+				})
 			}
 			data, _ := json.Marshal(patch)
 			log.WithField("data", string(data)).Debug("patching pod")
-			_, err := pods.Patch(
+			_, err = pods.Patch(
 				ctx,
 				podName,
 				types.JSONPatchType,
@@ -553,19 +554,20 @@ func (wfc *WorkflowController) processNextPodCleanupItem(ctx context.Context) bo
 			}
 		case deletePod:
 			var patch []common.DeleteFinalizerPatch
-			obj, _, _ := wfc.podInformer.GetIndexer().GetByKey(namespace + "/" + podName)
-			if p, ok := obj.(*apiv1.Pod); ok {
-				i := slices.Index(p.Finalizers, common.Finalizer)
-				if i >= 0 {
-					patch = append(patch, common.DeleteFinalizerPatch{
-						Operation: "remove",
-						Path:      fmt.Sprintf("/metadata/finalizers/%d", i),
-					})
-				}
+			p, err := wfc.getPodFromApi(ctx, namespace, podName)
+			if err != nil {
+				return err
+			}
+			i := slices.Index(p.Finalizers, common.Finalizer)
+			if i >= 0 {
+				patch = append(patch, common.DeleteFinalizerPatch{
+					Operation: "remove",
+					Path:      fmt.Sprintf("/metadata/finalizers/%d", i),
+				})
 			}
 			data, _ := json.Marshal(patch)
 			log.WithField("data", string(data)).Debug("patching pod")
-			_, err := pods.Patch(
+			_, err = pods.Patch(
 				ctx,
 				podName,
 				types.JSONPatchType,
@@ -595,7 +597,15 @@ func (wfc *WorkflowController) processNextPodCleanupItem(ctx context.Context) bo
 	return true
 }
 
-func (wfc *WorkflowController) getPod(namespace string, podName string) (*apiv1.Pod, error) {
+func (wfc *WorkflowController) getPodFromApi(ctx context.Context, namespace string, podName string) (*apiv1.Pod, error) {
+	pod, err := wfc.kubeclientset.CoreV1().Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return pod, nil
+}
+
+func (wfc *WorkflowController) getPodFromCache(namespace string, podName string) (*apiv1.Pod, error) {
 	obj, exists, err := wfc.podInformer.GetStore().GetByKey(namespace + "/" + podName)
 	if err != nil {
 		return nil, err
@@ -611,7 +621,7 @@ func (wfc *WorkflowController) getPod(namespace string, podName string) (*apiv1.
 }
 
 func (wfc *WorkflowController) signalContainers(namespace string, podName string, sig syscall.Signal) (time.Duration, error) {
-	pod, err := wfc.getPod(namespace, podName)
+	pod, err := wfc.getPodFromCache(namespace, podName)
 	if pod == nil || err != nil {
 		return 0, err
 	}

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -2503,7 +2503,7 @@ func (woc *wfOperationCtx) getPodByNode(node *wfv1.NodeStatus) (*apiv1.Pod, erro
 	}
 
 	podName := woc.getPodName(node.Name, node.TemplateName)
-	return woc.controller.getPod(woc.wf.GetNamespace(), podName)
+	return woc.controller.getPodFromCache(woc.wf.GetNamespace(), podName)
 }
 
 func (woc *wfOperationCtx) recordNodePhaseEvent(node *wfv1.NodeStatus) {


### PR DESCRIPTION
Fixes https://github.com/argoproj/argo-workflows/pull/9058

<!--

Before you commit your changes:

* Run `make pre-commit -B` to fix codegen and lint problems.
* Add you organization to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md) if you like.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If the CI fails for an e2e test first check to see if it's caused by something you touched. 
If not, sometimes tests can fail due to timing and you can issue an empty commit 
(```git commit --allow-empty -s -m "fix: empty commit"```) to retry.

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->

## Motivation
I need to fix the pod deleted problem asap, so I am trying to fix https://github.com/argoproj/argo-workflows/pull/9058 flake test.

## Modifications
Use the Kubernetes API instead of SharedInformer when `parsePodCleanupKey` tries to get `apiv1.Pod`.

## Verification
Correctly run tests on local

## Reproduce flake test
Run the following commands on the finalizer branch on the devcontainer, and then sometimes you can reproduce the flake test.
```shell
$ make start PROFILE=minimal AUTH_MODE=client STATIC_FILES=false LOG_LEVEL=debug API=false UI=false
# another terminal
$ go test -failfast -v -timeout 20m -count 1 --tags functional -parallel 20 ./test/e2e -run='PodCleanupSuite'